### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/dragonwell`
 
-The Paketo Alibaba Dragonwell Buildpack is a Cloud Native Buildpack that provides the Alibaba Dragonwell implementations of JREs and JDKs.
+The Paketo Buildpack for Alibaba Dragonwell is a Cloud Native Buildpack that provides the Alibaba Dragonwell implementations of JREs and JDKs.
 
 This buildpack is designed to work in collaboration with other buildpacks which request contributions of JREs and JDKs.
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/alibaba-dragonwell"
   id = "paketo-buildpacks/alibaba-dragonwell"
   keywords = ["java", "jvm", "jre", "jdk"]
-  name = "Paketo Alibaba Dragonwell Buildpack"
+  name = "Paketo Buildpack for Alibaba Dragonwell"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Alibaba Dragonwell Buildpack' to 'Paketo Buildpack for Alibaba Dragonwell'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
